### PR TITLE
Tweaks in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,10 +38,9 @@ defmodule ExFirebaseAuth.MixProject do
 
   defp package do
     [
-      description: "Handling Firebase Auth 'ID tokens' in Elixir",
+      description: "Handle ID Tokens from the Firebase Authentication service",
       links: %{
-        "github" => "https://github.com/Nickforall/ExFirebaseAuth",
-        "documentation" => "https://hexdocs.pm/ex_firebase_auth"
+        "GitHub" => "https://github.com/Nickforall/ExFirebaseAuth"
       },
       licenses: ["MIT"]
     ]


### PR DESCRIPTION
Minor tweaks on `mix.exs`: a clearer description of what the library do (with proper casing and naming), and I'm removing the additional documentation link from the Hex page (Hex generates a documentation link by default - the "Online documentation" one, so no need to have two of them).