### PR TITLE
Add exception handling for invalid JWT

### DIFF
--- a/lib/token.ex
+++ b/lib/token.ex
@@ -36,8 +36,7 @@ defmodule ExFirebaseAuth.Token do
   def verify_token(token_string) do
     issuer = issuer()
 
-    with {:jwtheader, %{fields: %{"kid" => kid}}} <-
-           {:jwtheader, JOSE.JWT.peek_protected(token_string)},
+    with {:jwtheader, %{fields: %{"kid" => kid}}} <- peek_token_kid(token_string),
          # read key from store
          {:key, %JOSE.JWK{} = key} <- {:key, get_public_key(kid)},
          # check if verify returns true and issuer matches
@@ -45,6 +44,9 @@ defmodule ExFirebaseAuth.Token do
            {:verify, JOSE.JWT.verify(key, token_string)} do
       {:ok, sub, data}
     else
+      :invalidjwt ->
+        {:error, "Invalid JWT"}
+
       {:jwtheader, _} ->
         {:error, "Invalid JWT header, `kid` missing"}
 
@@ -60,5 +62,11 @@ defmodule ExFirebaseAuth.Token do
       {:verify, _} ->
         {:error, "None of public keys matched auth token's key ids"}
     end
+  end
+
+  defp peek_token_kid(token_string) do
+    {:jwtheader, JOSE.JWT.peek_protected(token_string)}
+  rescue
+    _ -> :invalidjwt
   end
 end

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -143,4 +143,12 @@ defmodule ExFirebaseAuth.TokenTest do
 
     assert {:error, "Signed by invalid issuer"} = Token.verify_token(token)
   end
+
+  test "Does fail on invalid JWT with raised exception handled" do
+    Application.put_env(:ex_firebase_auth, :issuer, "issuer")
+
+    invalid_token = "invalid.jwt.token"
+
+    assert {:error, "Invalid JWT"} = Token.verify_token(invalid_token)
+  end
 end


### PR DESCRIPTION
* JOSE.JWT raises exceptions when JWT token string is invalid
* this gracefully handles this case by handling raised exceptions

Fixes: #12 

Picking up from #16 - since PR #16 haven't moved since 8 months ago 

(p.s. very nice package @Nickforall :)