### PR TITLE
Support verifying cookies from Firebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added support for verifying session cookies.
+
 ## 0.5.1
 
 - Set default expiry on mocked token to 1 hour from utc now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added support for verifying session cookies.
+- Added `ExFirebaseAuth.Cookie` to support for verifying session cookies.
 
 ## 0.5.1
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,23 @@ end
 Add the Firebase auth issuer name for your project to your `config.exs`. This is required to make sure only your project's firebase tokens are accepted.
 
 ```elixir
-config :ex_firebase_auth, :issuer, "https://securetoken.google.com/project-123abc"
+config :ex_firebase_auth,
+  issuer: "https://securetoken.google.com/project-123abc",
+  # See https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects/createSessionCookie
+  cookie_issuer: "https://session.firebase.google.com/project-123abc"
 ```
 
 Verifying a token
 
 ```elixir
 ExFirebaseAuth.Token.verify_token("Some token string")
+iex> {:ok, "userid", %{}}
+```
+
+Verifying a cookie
+
+```elixir
+ExFirebaseAuth.Token.verify_cookie("Some token string")
 iex> {:ok, "userid", %{}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ iex> {:ok, "userid", %{}}
 Verifying a cookie
 
 ```elixir
-ExFirebaseAuth.Token.verify_cookie("Some token string")
+ExFirebaseAuth.Cookie.verify_cookie("Some token string")
 iex> {:ok, "userid", %{}}
 ```
 

--- a/lib/cookie.ex
+++ b/lib/cookie.ex
@@ -9,20 +9,20 @@ defmodule ExFirebaseAuth.Cookie do
   """
   def issuer, do: Application.fetch_env!(:ex_firebase_auth, :cookie_issuer)
 
-  @spec verify(String.t()) ::
+  @spec verify_cookie(String.t()) ::
           {:error, String.t()} | {:ok, String.t(), JOSE.JWT.t()}
   @doc ~S"""
   Verifies a cookie token agains Google's public keys. Returns {:ok, user_id, claims} if successful. {:error, _} otherwise.
 
   ## Examples
 
-      iex> ExFirebaseAuth.Cookie.verify("ey.some.token")
+      iex> ExFirebaseAuth.Cookie.verify_cookie("ey.some.token")
       {:ok, "user id", %{}}
 
-      iex> ExFirebaseAuth.Cookie.verify("ey.some.token")
+      iex> ExFirebaseAuth.Cookie.verify_cookie("ey.some.token")
       {:error, "Invalid JWT header, `kid` missing"}
   """
-  def verify(cookie_string) do
+  def verify_cookie(cookie_string) do
     ExFirebaseAuth.Token.verify_token(cookie_string, issuer())
   end
 end

--- a/lib/cookie.ex
+++ b/lib/cookie.ex
@@ -1,0 +1,28 @@
+defmodule ExFirebaseAuth.Cookie do
+  @doc ~S"""
+  Returns the configured issuer
+
+  ## Examples
+
+      iex> ExFirebaseAuth.Token.issuer()
+      "https://session.firebase.google.com/project-123abc"
+  """
+  def issuer, do: Application.fetch_env!(:ex_firebase_auth, :cookie_issuer)
+
+  @spec verify(String.t()) ::
+          {:error, String.t()} | {:ok, String.t(), JOSE.JWT.t()}
+  @doc ~S"""
+  Verifies a cookie token agains Google's public keys. Returns {:ok, user_id, claims} if successful. {:error, _} otherwise.
+
+  ## Examples
+
+      iex> ExFirebaseAuth.Cookie.verify("ey.some.token")
+      {:ok, "user id", %{}}
+
+      iex> ExFirebaseAuth.Cookie.verify("ey.some.token")
+      {:error, "Invalid JWT header, `kid` missing"}
+  """
+  def verify(cookie_string) do
+    ExFirebaseAuth.Token.verify_token(cookie_string, issuer())
+  end
+end

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -114,7 +114,7 @@ defmodule ExFirebaseAuth.Mock do
 
     jwt =
       Map.merge(claims, %{
-        "iss" => ExFirebaseAuth.Token.cookie_issuer(),
+        "iss" => ExFirebaseAuth.Cookie.issuer(),
         "sub" => sub
       })
 

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -87,6 +87,42 @@ defmodule ExFirebaseAuth.Mock do
     payload
   end
 
+  @spec generate_cookie(String.t(), map) :: String.t()
+  @doc ~S"""
+  Generates a firebase-like session cookie token with the mock's private key. Will raise when mock is not enabled.
+
+  ## Examples
+
+      iex> ExFirebaseAuth.Mock.generate_cookie("userid", %{"claim" => "value"})
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlLCJpc3MiOiJqb2UifQ.shLcxOl_HBBsOTvPnskfIlxHUibPN7Y9T4LhPB-iBwM"
+  """
+  def generate_cookie(sub, claims \\ %{}) do
+    unless is_enabled?() do
+      raise "Cannot generate mocked token, because ExFirebaseAuth.Mock is not enabled in your config."
+    end
+
+    {kid, jwk} = get_private_key()
+
+    jws = %{
+      "alg" => "RS256",
+      "kid" => kid
+    }
+
+    # Put exp claim, unless previously specified in claims
+    exp = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_unix()
+    claims = Map.put_new(claims, "exp", exp)
+
+    jwt =
+      Map.merge(claims, %{
+        "iss" => ExFirebaseAuth.Token.cookie_issuer(),
+        "sub" => sub
+      })
+
+    {_, payload} = JOSE.JWT.sign(jwk, jws, jwt) |> JOSE.JWS.compact()
+
+    payload
+  end
+
   defp mock_config, do: Application.get_env(:ex_firebase_auth, :mock, [])
 
   defp find_or_create_private_key_table do

--- a/lib/source/google_key_source.ex
+++ b/lib/source/google_key_source.ex
@@ -1,18 +1,30 @@
 defmodule ExFirebaseAuth.KeySource.Google do
   @moduledoc false
 
-  @endpoint_url "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
+  @endpoint_urls [
+    "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com",
+    "https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys"
+  ]
 
   @behaviour ExFirebaseAuth.KeySource
 
   def fetch_certificates do
-    with {:ok, %Finch.Response{body: body}} <-
-           Finch.build(:get, @endpoint_url) |> Finch.request(ExFirebaseAuthFinch),
-         {:ok, json_data} <- Jason.decode(body) do
-      {:ok, convert_to_jose_keys(json_data)}
+    results =
+      @endpoint_urls
+      |> Enum.map(fn endpoint_url ->
+        with {:ok, %Finch.Response{body: body}} <-
+               Finch.build(:get, endpoint_url) |> Finch.request(ExFirebaseAuthFinch),
+             {:ok, json_data} <- Jason.decode(body) do
+          {:ok, convert_to_jose_keys(json_data)}
+        else
+          _ -> :error
+        end
+      end)
+
+    if Enum.any?(results, &(&1 == :error)) do
+      :error
     else
-      _ ->
-        :error
+      {:ok, Enum.reduce(results, %{}, fn {:ok, result}, acc -> Enum.into(result, acc) end)}
     end
   end
 

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -20,17 +20,6 @@ defmodule ExFirebaseAuth.Token do
   """
   def issuer, do: Application.fetch_env!(:ex_firebase_auth, :issuer)
 
-  @spec cookie_issuer :: String.t()
-  @doc ~S"""
-  Returns the configured issuer
-
-  ## Examples
-
-      iex> ExFirebaseAuth.Token.issuer()
-      "https://session.firebase.google.com/project-123abc"
-  """
-  def cookie_issuer, do: Application.fetch_env!(:ex_firebase_auth, :cookie_issuer)
-
   @spec verify_token(String.t()) ::
           {:error, String.t()} | {:ok, String.t(), JOSE.JWT.t()}
   @doc ~S"""
@@ -45,27 +34,10 @@ defmodule ExFirebaseAuth.Token do
       {:error, "Invalid JWT header, `kid` missing"}
   """
   def verify_token(token_string) do
-    do_verify_token(token_string, issuer())
+    verify_token(token_string, issuer())
   end
 
-  @spec verify_cookie(String.t()) ::
-          {:error, String.t()} | {:ok, String.t(), JOSE.JWT.t()}
-  @doc ~S"""
-  Verifies a cookie token agains Google's public keys. Returns {:ok, user_id, claims} if successful. {:error, _} otherwise.
-
-  ## Examples
-
-      iex> ExFirebaseAuth.Token.verify_cookie("ey.some.token")
-      {:ok, "user id", %{}}
-
-      iex> ExFirebaseAuth.Token.verify_cookie("ey.some.token")
-      {:error, "Invalid JWT header, `kid` missing"}
-  """
-  def verify_cookie(cookie_string) do
-    do_verify_token(cookie_string, cookie_issuer())
-  end
-
-  defp do_verify_token(token_string, issuer) do
+  def verify_token(token_string, issuer) do
     with {:jwtheader, %{fields: %{"kid" => kid}}} <- peek_token_kid(token_string),
          # read key from store
          {:key, %JOSE.JWK{} = key} <- {:key, get_public_key(kid)},

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -23,7 +23,7 @@ defmodule ExFirebaseAuth.Token do
   @spec verify_token(String.t()) ::
           {:error, String.t()} | {:ok, String.t(), JOSE.JWT.t()}
   @doc ~S"""
-  Verifies a token agains Google's public keys. Returns {:ok, user_id, claims} if successful. {:error, _} otherwise.
+  Verifies a token against Google's public keys. Returns {:ok, user_id, claims} if successful. {:error, _} otherwise.
 
   ## Examples
 

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -71,7 +71,7 @@ defmodule ExFirebaseAuth.Token do
          {:key, %JOSE.JWK{} = key} <- {:key, get_public_key(kid)},
          # check if verify returns true and issuer matches
          {:verify, {true, %{fields: %{"iss" => ^issuer, "sub" => sub, "exp" => exp}} = data, _}} <-
-           {:verify, JOSE.JWT.verify(key, token_string)} |> IO.inspect(),
+           {:verify, JOSE.JWT.verify(key, token_string)},
          # Verify exp date
          {:verify, {:ok, _}} <- {:verify, verify_expiry(exp)} do
       {:ok, sub, data}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExFirebaseAuth.MixProject do
   def project do
     [
       app: :ex_firebase_auth,
-      version: "0.5.1",
+      version: "0.6.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -30,8 +30,8 @@ defmodule ExFirebaseAuth.MixProject do
   defp deps do
     [
       {:jose, "~> 1.10"},
-      {:finch, "~> 0.10.0"},
-      {:jason, "~> 1.3.0"},
+      {:finch, "~> 0.10"},
+      {:jason, "~> 1.3"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end

--- a/test/cookie_test.exs
+++ b/test/cookie_test.exs
@@ -1,12 +1,12 @@
-defmodule ExFirebaseAuth.TokenTest do
+defmodule ExFirebaseAuth.CookieTest do
   use ExUnit.Case
 
   alias ExFirebaseAuth.{
-    Token,
+    Cookie,
     Mock
   }
 
-  defp generate_token(claims, jws) do
+  defp generate_cookie(claims, jws) do
     [{_kid, jwk}] = :ets.lookup(ExFirebaseAuth.Mock, :ets.first(ExFirebaseAuth.Mock))
 
     {_, payload} = JOSE.JWT.sign(jwk, jws, claims) |> JOSE.JWS.compact()
@@ -20,20 +20,20 @@ defmodule ExFirebaseAuth.TokenTest do
 
     on_exit(fn ->
       :ok = Application.delete_env(:ex_firebase_auth, :mock)
-      :ok = Application.delete_env(:ex_firebase_auth, :issuer)
+      :ok = Application.delete_env(:ex_firebase_auth, :cookie_issuer)
     end)
   end
 
-  describe "Token.verify_token/1" do
+  describe "Cookie.verify/1" do
     test "Does succeed on correct token" do
       issuer = Enum.random(?a..?z)
-      Application.put_env(:ex_firebase_auth, :issuer, issuer)
+      Application.put_env(:ex_firebase_auth, :cookie_issuer, issuer)
 
       sub = Enum.random(?a..?z)
       time_in_future = DateTime.utc_now() |> DateTime.add(360, :second) |> DateTime.to_unix()
       claims = %{"exp" => time_in_future}
-      valid_token = Mock.generate_token(sub, claims)
-      assert {:ok, ^sub, jwt} = Token.verify_token(valid_token)
+      valid_token = Mock.generate_cookie(sub, claims)
+      assert {:ok, ^sub, jwt} = Cookie.verify(valid_token)
 
       %JOSE.JWT{
         fields: %{
@@ -47,25 +47,25 @@ defmodule ExFirebaseAuth.TokenTest do
     end
 
     test "Does raise on no issuer being set" do
-      Application.put_env(:ex_firebase_auth, :issuer, "issuer")
-      valid_token = Mock.generate_token("subsub")
-      Application.delete_env(:ex_firebase_auth, :issuer)
+      Application.put_env(:ex_firebase_auth, :cookie_issuer, "issuer")
+      valid_token = Mock.generate_cookie("subsub")
+      Application.delete_env(:ex_firebase_auth, :cookie_issuer)
 
       assert_raise(
         ArgumentError,
-        ~r/^could not fetch application environment :issuer for application :ex_firebase_auth because configuration at :issuer was not set/,
+        ~r/^could not fetch application environment :cookie_issuer for application :ex_firebase_auth because configuration at :cookie_issuer was not set/,
         fn ->
-          Token.verify_token(valid_token)
+          Cookie.verify(valid_token)
         end
       )
     end
 
     test "Does fail on no `kid` being set in JWT header" do
       sub = Enum.random(?a..?z)
-      Application.put_env(:ex_firebase_auth, :issuer, "issuer")
+      Application.put_env(:ex_firebase_auth, :cookie_issuer, "issuer")
 
       token =
-        generate_token(
+        generate_cookie(
           %{
             "sub" => sub,
             "iss" => "issuer"
@@ -75,16 +75,16 @@ defmodule ExFirebaseAuth.TokenTest do
           }
         )
 
-      assert {:error, "Invalid JWT header, `kid` missing"} = Token.verify_token(token)
+      assert {:error, "Invalid JWT header, `kid` missing"} = Cookie.verify(token)
     end
   end
 
   test "Does fail invalid kid being set" do
     sub = Enum.random(?a..?z)
-    Application.put_env(:ex_firebase_auth, :issuer, "issuer")
+    Application.put_env(:ex_firebase_auth, :cookie_issuer, "issuer")
 
     token =
-      generate_token(
+      generate_cookie(
         %{
           "sub" => sub,
           "iss" => "issuer"
@@ -96,12 +96,12 @@ defmodule ExFirebaseAuth.TokenTest do
       )
 
     assert {:error, "Public key retrieved from google was not found or could not be parsed"} =
-             Token.verify_token(token)
+             Cookie.verify(token)
   end
 
   test "Does fail on invalid signature with non-matching kid" do
     sub = Enum.random(?a..?z)
-    Application.put_env(:ex_firebase_auth, :issuer, "issuer")
+    Application.put_env(:ex_firebase_auth, :cookie_issuer, "issuer")
 
     {_invalid_kid, public_key, private_key} = Mock.generate_key()
 
@@ -122,17 +122,17 @@ defmodule ExFirebaseAuth.TokenTest do
       )
       |> JOSE.JWS.compact()
 
-    assert {:error, "Invalid signature"} = Token.verify_token(token)
+    assert {:error, "Invalid signature"} = Cookie.verify(token)
   end
 
   test "Does fail on invalid issuer" do
     sub = Enum.random(?a..?z)
-    Application.put_env(:ex_firebase_auth, :issuer, "issuer")
+    Application.put_env(:ex_firebase_auth, :cookie_issuer, "issuer")
 
     [{kid, _}] = :ets.lookup(ExFirebaseAuth.Mock, :ets.first(ExFirebaseAuth.Mock))
 
     token =
-      generate_token(
+      generate_cookie(
         %{
           "sub" => sub,
           "iss" => "bogusissuer"
@@ -143,28 +143,28 @@ defmodule ExFirebaseAuth.TokenTest do
         }
       )
 
-    assert {:error, "Signed by invalid issuer"} = Token.verify_token(token)
+    assert {:error, "Signed by invalid issuer"} = Cookie.verify(token)
   end
 
   test "Does fail on invalid JWT with raised exception handled" do
-    Application.put_env(:ex_firebase_auth, :issuer, "issuer")
+    Application.put_env(:ex_firebase_auth, :cookie_issuer, "issuer")
 
     invalid_token = "invalid.jwt.token"
 
-    assert {:error, "Invalid JWT"} = Token.verify_token(invalid_token)
+    assert {:error, "Invalid JWT"} = Cookie.verify(invalid_token)
   end
 
   test "Does fail on expired JWT" do
     issuer = Enum.random(?a..?z)
-    Application.put_env(:ex_firebase_auth, :issuer, issuer)
+    Application.put_env(:ex_firebase_auth, :cookie_issuer, issuer)
 
     sub = Enum.random(?a..?z)
 
     time_in_past = DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.to_unix()
     claims = %{"exp" => time_in_past}
 
-    valid_token = Mock.generate_token(sub, claims)
+    valid_token = Mock.generate_cookie(sub, claims)
 
-    assert {:error, "Expired JWT"} = Token.verify_token(valid_token)
+    assert {:error, "Expired JWT"} = Cookie.verify(valid_token)
   end
 end

--- a/test/cookie_test.exs
+++ b/test/cookie_test.exs
@@ -24,7 +24,7 @@ defmodule ExFirebaseAuth.CookieTest do
     end)
   end
 
-  describe "Cookie.verify/1" do
+  describe "Cookie.verify_cookie/1" do
     test "Does succeed on correct token" do
       issuer = Enum.random(?a..?z)
       Application.put_env(:ex_firebase_auth, :cookie_issuer, issuer)
@@ -33,7 +33,7 @@ defmodule ExFirebaseAuth.CookieTest do
       time_in_future = DateTime.utc_now() |> DateTime.add(360, :second) |> DateTime.to_unix()
       claims = %{"exp" => time_in_future}
       valid_token = Mock.generate_cookie(sub, claims)
-      assert {:ok, ^sub, jwt} = Cookie.verify(valid_token)
+      assert {:ok, ^sub, jwt} = Cookie.verify_cookie(valid_token)
 
       %JOSE.JWT{
         fields: %{
@@ -55,7 +55,7 @@ defmodule ExFirebaseAuth.CookieTest do
         ArgumentError,
         ~r/^could not fetch application environment :cookie_issuer for application :ex_firebase_auth because configuration at :cookie_issuer was not set/,
         fn ->
-          Cookie.verify(valid_token)
+          Cookie.verify_cookie(valid_token)
         end
       )
     end
@@ -75,7 +75,7 @@ defmodule ExFirebaseAuth.CookieTest do
           }
         )
 
-      assert {:error, "Invalid JWT header, `kid` missing"} = Cookie.verify(token)
+      assert {:error, "Invalid JWT header, `kid` missing"} = Cookie.verify_cookie(token)
     end
   end
 
@@ -96,7 +96,7 @@ defmodule ExFirebaseAuth.CookieTest do
       )
 
     assert {:error, "Public key retrieved from google was not found or could not be parsed"} =
-             Cookie.verify(token)
+             Cookie.verify_cookie(token)
   end
 
   test "Does fail on invalid signature with non-matching kid" do
@@ -122,7 +122,7 @@ defmodule ExFirebaseAuth.CookieTest do
       )
       |> JOSE.JWS.compact()
 
-    assert {:error, "Invalid signature"} = Cookie.verify(token)
+    assert {:error, "Invalid signature"} = Cookie.verify_cookie(token)
   end
 
   test "Does fail on invalid issuer" do
@@ -143,7 +143,7 @@ defmodule ExFirebaseAuth.CookieTest do
         }
       )
 
-    assert {:error, "Signed by invalid issuer"} = Cookie.verify(token)
+    assert {:error, "Signed by invalid issuer"} = Cookie.verify_cookie(token)
   end
 
   test "Does fail on invalid JWT with raised exception handled" do
@@ -151,7 +151,7 @@ defmodule ExFirebaseAuth.CookieTest do
 
     invalid_token = "invalid.jwt.token"
 
-    assert {:error, "Invalid JWT"} = Cookie.verify(invalid_token)
+    assert {:error, "Invalid JWT"} = Cookie.verify_cookie(invalid_token)
   end
 
   test "Does fail on expired JWT" do
@@ -165,6 +165,6 @@ defmodule ExFirebaseAuth.CookieTest do
 
     valid_token = Mock.generate_cookie(sub, claims)
 
-    assert {:error, "Expired JWT"} = Cookie.verify(valid_token)
+    assert {:error, "Expired JWT"} = Cookie.verify_cookie(valid_token)
   end
 end


### PR DESCRIPTION
This PR adds support for verifying session cookies from Firebase. They are JWTs that have the same shape as idTokens, but are longer lived for backend applications. The difference is the `kid` values are unique between idToken and sessionCookies payloads.

I did my best to work inside the existing API to avoid any major rewrite, but am happy to adjust the approach.

## Other Changes

I loosened the version constraints on Finch