### PR TITLE
✨ Add support for multiple configs, useful in umbrella apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the Firebase auth issuer name for your project to your `config.exs`. This is
 ```elixir
 config :ex_firebase_auth, :issuer, "https://securetoken.google.com/project-123abc"
 ```
-or if you'd like to define a different issue per app
+or if you'd like to define a different issuer per app
 ```elixir
 config :your_app, :ex_firebase_auth, 
   issuer: "https://securetoken.google.com/project-123abc"

--- a/README.md
+++ b/README.md
@@ -34,11 +34,21 @@ Add the Firebase auth issuer name for your project to your `config.exs`. This is
 ```elixir
 config :ex_firebase_auth, :issuer, "https://securetoken.google.com/project-123abc"
 ```
+or if you'd like to define a different issue per app
+```elixir
+config :your_app, :ex_firebase_auth, 
+  issuer: "https://securetoken.google.com/project-123abc"
+```
 
 Verifying a token
 
 ```elixir
 ExFirebaseAuth.Token.verify_token("Some token string")
+iex> {:ok, "userid", %{}}
+```
+or
+```elixir
+ExFirebaseAuth.Token.verify_token("Some token string", :your_app)
 iex> {:ok, "userid", %{}}
 ```
 

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -60,7 +60,7 @@ defmodule ExFirebaseAuth.Mock do
       iex> ExFirebaseAuth.Mock.generate_token("userid", %{"claim" => "value"})
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlLCJpc3MiOiJqb2UifQ.shLcxOl_HBBsOTvPnskfIlxHUibPN7Y9T4LhPB-iBwM"
   """
-  def generate_token(sub, claims \\ %{}) do
+  def generate_token(sub, claims \\ %{}, app \\ :ex_firebase_auth) do
     unless is_enabled?() do
       raise "Cannot generate mocked token, because ExFirebaseAuth.Mock is not enabled in your config."
     end
@@ -78,7 +78,7 @@ defmodule ExFirebaseAuth.Mock do
 
     jwt =
       Map.merge(claims, %{
-        "iss" => ExFirebaseAuth.Token.issuer(),
+        "iss" => ExFirebaseAuth.Token.issuer(app),
         "sub" => sub
       })
 

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -51,7 +51,7 @@ defmodule ExFirebaseAuth.Mock do
     {kid, public_key, private_key}
   end
 
-  @spec generate_token(String.t(), map) :: String.t()
+  @spec generate_token(String.t(), map, atom) :: String.t()
   @doc ~S"""
   Generates a firebase-like ID token with the mock's private key. Will raise when mock is not enabled.
 
@@ -59,6 +59,9 @@ defmodule ExFirebaseAuth.Mock do
 
       iex> ExFirebaseAuth.Mock.generate_token("userid", %{"claim" => "value"})
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlLCJpc3MiOiJqb2UifQ.shLcxOl_HBBsOTvPnskfIlxHUibPN7Y9T4LhPB-iBwM"
+
+      iex> ExFirebaseAuth.Mock.generate_token("userid", %{"claim" => "value"}, :your_app)
+      "aeHaajfIOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlLCJpc3MiOiJqb2UifQ.shLcxOl_HBBsOTvPnskfIlxHUibPN7Y9T4LhPB-iBwM"
   """
   def generate_token(sub, claims \\ %{}, app \\ :ex_firebase_auth) do
     unless is_enabled?() do

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -23,7 +23,9 @@ defmodule ExFirebaseAuth.Token do
   """
   def issuer(app \\ @default_app), do: do_get_issuer(app)
   defp do_get_issuer(@default_app), do: Application.fetch_env!(@default_app, :issuer)
-  defp do_get_issuer(app), do: Application.fetch_env!(app, @default_app) |> Keyword.fetch!(:issuer)
+
+  defp do_get_issuer(app),
+    do: Application.fetch_env!(app, @default_app) |> Keyword.fetch!(:issuer)
 
   @spec verify_token(String.t(), atom()) ::
           {:error, String.t()} | {:ok, String.t(), JOSE.JWT.t()}
@@ -39,7 +41,7 @@ defmodule ExFirebaseAuth.Token do
       {:error, "Invalid JWT header, `kid` missing"}
   """
   def verify_token(token_string, app \\ @default_app) do
-    issuer = issuer(app)
+    issuer = issuer(app) |> IO.inspect(label: :verify_token_issuer)
 
     with {:jwtheader, %{fields: %{"kid" => kid}}} <- peek_token_kid(token_string),
          # read key from store

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -20,6 +20,9 @@ defmodule ExFirebaseAuth.Token do
 
       iex> ExFirebaseAuth.Token.issuer()
       "https://securetoken.google.com/project-123abc"
+
+      iex> ExFirebaseAuth.Token.issuer(:my_other_project)
+      "https://securetoken.google.com/other-project-123abc"
   """
   def issuer(app \\ @default_app), do: do_get_issuer(app)
   defp do_get_issuer(@default_app), do: Application.fetch_env!(@default_app, :issuer)
@@ -35,6 +38,9 @@ defmodule ExFirebaseAuth.Token do
   ## Examples
 
       iex> ExFirebaseAuth.Token.verify_token("ey.some.token")
+      {:ok, "user id", %{}}
+
+      iex> ExFirebaseAuth.Token.verify_token("ey.some.token", :my_app)
       {:ok, "user id", %{}}
 
       iex> ExFirebaseAuth.Token.verify_token("ey.some.token")

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -47,7 +47,7 @@ defmodule ExFirebaseAuth.Token do
       {:error, "Invalid JWT header, `kid` missing"}
   """
   def verify_token(token_string, app \\ @default_app) do
-    issuer = issuer(app) |> IO.inspect(label: :verify_token_issuer)
+    issuer = issuer(app)
 
     with {:jwtheader, %{fields: %{"kid" => kid}}} <- peek_token_kid(token_string),
          # read key from store


### PR DESCRIPTION
Hi, thanks for this library. It is quite useful and easy to use :) 

As per the title, when using this library in an umbrella app I'd like to have the option to use a different issuer for different applications inside my umbrella app. Currently this is impossible because the library always looks for `:ex_firebase_auth` and umbrella apps all share the same config.

With this change we can optionally specify an app when calling Token.verify_token and Token.issuer, and the library will look for the config on that app.

This change should not affect existing code in any way.
I didn't look to deeply into the KeyStore part of the library, but from a quick glance it seems like there was no need to do any changes to achieve the goal.

Comments and suggested improvements are more than welcome.
Thanks!